### PR TITLE
Adds SF2 on board CSRF protection

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -23,6 +23,7 @@ security:
             form_login:
                 check_path: login_check
                 login_path: login
+                csrf_provider: form.csrf_provider
             logout:
                 path:   logout
                 target: home

--- a/src/AppBundle/Resources/views/Security/login.html.twig
+++ b/src/AppBundle/Resources/views/Security/login.html.twig
@@ -8,6 +8,8 @@
         <label for="password">Password:</label>
         <input type="password" id="password" name="_password" />
 
+        <input type="hidden" name="_csrf_token" value="{{ csrf_token('authenticate') }}" />
+
         <button type="submit">login</button>
     </form>
 {% endblock %}


### PR DESCRIPTION
This feature branch adds a CSRF token protection for the login form. It uses the symfony2 standard mechanisms described here: 
http://symfony.com/doc/2.6/cookbook/security/csrf_in_login_form.html